### PR TITLE
add very basic github action

### DIFF
--- a/.github/conan-config/profiles/default
+++ b/.github/conan-config/profiles/default
@@ -1,0 +1,4 @@
+include(autodetected)
+
+[settings]
+compiler.cppstd={% if platform.system() == "Windows" %}17{% else %}gnu17{% endif %}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,4 @@ jobs:
       - name: conan create cutlass
         run: conan create recipes/cutlass/all --version 4.3.5
 
-      - name: conan create libtorch
-        # version 2.9.1 of libtorch did not work with newer CUDA,
-        # we build it against 12.9 and 13.0
-        if: matrix.cuda-version != '13.2'
-        run: conan create samples/libtorch/all --version 2.9.1 -o "*:shared=True"
+    # TODO: build samples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        cuda-version: ["12.9", "13.0", "13.2"]
+        include:
+          - os: ubuntu-latest
+            cuda-version: "12.9"
+          - os: ubuntu-latest
+            cuda-version: "13.0"
+          - os: ubuntu-latest
+            cuda-version: "13.2"
+          # Windows:
+          # cuda <13.2 requires Visual Studio 2022, available on windows-2022 runner
+          - os: windows-2022
+            cuda-version: "12.9"
+          - os: windows-2022
+            cuda-version: "13.0"
+          # cuda >=13.2 can run on windows-latest (Visual Studio 2026)
+          - os: windows-latest
+            cuda-version: "13.2"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,14 @@ jobs:
 
       - name: Setup Conan
         uses: conan-io/setup-conan@v1
+        with:
+          profile_detect: false
+
+      - name: Autodetect conan profile
+        run: conan profile detect --name autodetected
+
+      - name: Install Conan profile config
+        run: conan config install .github/conan-config -t dir
 
       - name: conan create cuda-toolkit
         run: conan create recipes/cuda-toolkit/${{ matrix.cuda-version }}
@@ -58,4 +66,4 @@ jobs:
         # version 2.9.1 of libtorch did not work with newer CUDA,
         # we build it against 12.9 and 13.0
         if: matrix.cuda-version != '13.2'
-        run: conan create samples/libtorch/all --version 2.9.1
+        run: conan create samples/libtorch/all --version 2.9.1 -o "*:shared=True"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  create-recipes:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        cuda-version: ["12.9", "13.0", "13.2"]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Conan
+        uses: conan-io/setup-conan@v1
+
+      - name: conan create
+        run: conan create recipes/cuda-toolkit/${{ matrix.cuda-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,26 @@ jobs:
       - name: Setup Conan
         uses: conan-io/setup-conan@v1
 
-      - name: conan create
+      - name: conan create cuda-toolkit
         run: conan create recipes/cuda-toolkit/${{ matrix.cuda-version }}
+
+      - name: conan create cudnn
+        run: conan create recipes/cudnn/9.x --version 9.24.0
+
+      - name: conan create cudnn-frontend
+        run: conan create recipes/cudnn-frontend/all --version 1.12.1
+
+      - name: conan create cudss
+        run: conan create recipes/cudss/0.7.1 --version 0.7.1
+
+      - name: conan create cusparselt
+        run: conan create recipes/cusparselt/0.8.1 --version 0.8.1
+
+      - name: conan create cutlass
+        run: conan create recipes/cutlass/all --version 4.3.5
+
+      - name: conan create libtorch
+        # version 2.9.1 of libtorch did not work with newer CUDA,
+        # we build it against 12.9 and 13.0
+        if: matrix.cuda-version != '13.2'
+        run: conan create samples/libtorch/all --version 2.9.1


### PR DESCRIPTION
Add a basic GitHub actions workflow to cover the following:
- cuda-toolkit 12.9 (most recent 12.x)
- cuda toolkit 13.0 (needed for our libtorch sample, as that version is not yet compatible with 13.2+)
- cuda-toolkit 13.2 (recent, but we really need 13.3)
- Windows and Linux
- all the other recipes

The way this is constructed ensures that the binary packages for CUDA 12.x and CUDA 13.x are built as part of testing.

Notes:
- `windows-latest` runners use Visual Studio 2026 - which requires toolkit >= 13.2
- use the `conan-io/setup-conan@v1` action, but override the `compiler.cppstd` setting to C++17
