### PR TITLE
Add a recipe for cuda-samples to build it locally

### DIFF
--- a/.github/conan-config/extensions/plugins/compatibility/compatibility.py
+++ b/.github/conan-config/extensions/plugins/compatibility/compatibility.py
@@ -1,0 +1,66 @@
+from conan.tools.build import supported_cppstd, supported_cstd
+from conan.errors import ConanException
+
+
+def cppstd_compat(conanfile):
+    # It will try to find packages with all the cppstd versions
+    extension_properties = getattr(conanfile, "extension_properties", {})
+    compiler = conanfile.settings.get_safe("compiler")
+    compiler_version = conanfile.settings.get_safe("compiler.version")
+    cppstd = conanfile.settings.get_safe("compiler.cppstd")
+    if not compiler or not compiler_version:
+        return []
+    factors = []  # List of list, each sublist is a potential combination
+    if cppstd is not None and extension_properties.get("compatibility_cppstd") is not False:
+        cppstd_possible_values = supported_cppstd(conanfile)
+        if cppstd_possible_values is None:
+            conanfile.output.warning(f'No cppstd compatibility defined for compiler "{compiler}"')
+        else: # The current cppst must be included in case there is other factor
+            factors.append([{"compiler.cppstd": v} for v in cppstd_possible_values])
+
+    cstd = conanfile.settings.get_safe("compiler.cstd")
+    if cstd is not None and extension_properties.get("compatibility_cstd") is not False:
+        cstd_possible_values = supported_cstd(conanfile)
+        if cstd_possible_values is None:
+            conanfile.output.warning(f'No cstd compatibility defined for compiler "{compiler}"')
+        else:
+            factors.append([{"compiler.cstd": v} for v in cstd_possible_values if v != cstd])
+    return factors
+
+
+def compatibility(conanfile):
+    # By default, different compiler.cppstd are compatible
+    # factors is a list of lists
+    factors = cppstd_compat(conanfile)
+
+    # MSVC version fallback compatibility (each entry falls back on earlier versions)
+    # deem binaries built with earlier versions as compatible
+    compiler = conanfile.settings.get_safe("compiler")
+    compiler_version = conanfile.settings.get_safe("compiler.version")
+    if compiler == "msvc":
+        msvc_fallbacks = {"194": ["193"], "195": ["194", "193"]}.get(compiler_version)
+        if msvc_fallbacks:
+            factors.append([{"compiler.version": v} for v in msvc_fallbacks])
+
+    # Append more factors for your custom compatibility rules here
+
+    # Combine factors to compute all possible configurations
+    combinations = _factors_combinations(factors)
+    # Final compatibility settings combinations to check
+    return [{"settings": [(k, v) for k, v in comb.items()]} for comb in combinations]
+
+
+def _factors_combinations(factors):
+    combinations = []
+    for factor in factors:
+        if not combinations:
+            combinations = factor
+            continue
+        new_combinations = []
+        for comb in combinations:
+            for f in factor:
+                new_comb = comb.copy()
+                new_comb.update(f)
+                new_combinations.append(new_comb)
+        combinations.extend(new_combinations)
+    return combinations

--- a/.github/conan-config/profiles/default
+++ b/.github/conan-config/profiles/default
@@ -5,4 +5,8 @@ compiler.cppstd={% if platform.system() == "Windows" %}17{% else %}gnu17{% endif
 
 [conf]
 tools.cmake.cmaketoolchain:extra_variables*={'CMAKE_CUDA_ARCHITECTURES':'75'}
+
+{% if platform.system() == "Linux" %}
 tools.system.package_manager:mode=install
+tools.system.package_manager:sudo=True
+{% endif %}

--- a/.github/conan-config/profiles/default
+++ b/.github/conan-config/profiles/default
@@ -10,3 +10,5 @@ tools.cmake.cmaketoolchain:extra_variables*={'CMAKE_CUDA_ARCHITECTURES':'75'}
 tools.system.package_manager:mode=install
 tools.system.package_manager:sudo=True
 {% endif %}
+
+cuda-samples/*:tools.cmake.cmaketoolchain:generator=Ninja

--- a/.github/conan-config/profiles/default
+++ b/.github/conan-config/profiles/default
@@ -5,3 +5,4 @@ compiler.cppstd={% if platform.system() == "Windows" %}17{% else %}gnu17{% endif
 
 [conf]
 tools.cmake.cmaketoolchain:extra_variables*={'CMAKE_CUDA_ARCHITECTURES':'75'}
+tools.system.package_manager:mode=install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,14 @@ jobs:
         if: matrix.cross-arch != ''
         run: conan test recipes/cuda-toolkit/${{ matrix.cuda-version }}/test_package cuda-toolkit/13.4.0-preview -s arch=${{ matrix.cross-arch }} -c tools.cmake.cmaketoolchain:generator=Ninja
 
+      - name: build cuda-samples
+        if: matrix.cuda-version == '13.2' || (matrix.cuda-version == '13.4' && startsWith(matrix.os, 'windows'))
+        working-directory: samples/cuda-samples
+        run: |
+          conan source .
+          conan install . --build=missing
+          conan build .
+
       # Skip the following for 13.4-preview
       - name: conan create cudnn
         if: matrix.cuda-version != '13.4'
@@ -83,5 +91,3 @@ jobs:
       - name: conan create cutlass
         if: matrix.cuda-version != '13.4'
         run: conan create recipes/cutlass/all --version 4.3.5
-
-    # TODO: build samples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,21 +75,21 @@ jobs:
 
       # Skip the following for 13.4-preview
       - name: conan create cudnn
-        if: matrix.cuda-version != '13.4'
+        if: matrix.cuda-version != '13.4' && !contains(matrix.os, '-arm')
         run: conan create recipes/cudnn/9.x --version 9.24.0 --build=missing
 
       - name: conan create cudnn-frontend
-        if: matrix.cuda-version != '13.4'
+        if: matrix.cuda-version != '13.4' && !contains(matrix.os, '-arm')
         run: conan create recipes/cudnn-frontend/all --version 1.12.1
 
       - name: conan create cudss
-        if: matrix.cuda-version != '13.4'
+        if: matrix.cuda-version != '13.4' && !contains(matrix.os, '-arm')
         run: conan create recipes/cudss/0.7.1 --version 0.7.1
 
       - name: conan create cusparselt
-        if: matrix.cuda-version != '13.4'
+        if: matrix.cuda-version != '13.4' && !contains(matrix.os, '-arm')
         run: conan create recipes/cusparselt/0.8.1 --version 0.8.1
 
       - name: conan create cutlass
-        if: matrix.cuda-version != '13.4'
+        if: matrix.cuda-version != '13.4' && !contains(matrix.os, '-arm')
         run: conan create recipes/cutlass/all --version 4.3.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
             cuda-version: "13.0"
           - os: ubuntu-latest
             cuda-version: "13.2"
+          - os: ubuntu-24.04-arm
+            cuda-version: "13.2"
           # Windows:
           # cuda <13.2 requires Visual Studio 2022, available on windows-2022 runner
           - os: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         working-directory: samples/cuda-samples
         run: |
           conan source .
-          conan install . --build=missing
+          conan install . --build=missing -cc core.version_ranges:resolve_prereleases=True
           conan build .
 
       # Skip the following for 13.4-preview

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,12 @@ jobs:
         run: |
           conan source .
           conan install . --build=missing -cc core.version_ranges:resolve_prereleases=True
-          conan build .
+          conan build . -cc core.version_ranges:resolve_prereleases=True
 
       # Skip the following for 13.4-preview
       - name: conan create cudnn
         if: matrix.cuda-version != '13.4'
-        run: conan create recipes/cudnn/9.x --version 9.24.0
+        run: conan create recipes/cudnn/9.x --version 9.24.0 --build=missing
 
       - name: conan create cudnn-frontend
         if: matrix.cuda-version != '13.4'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: conan test recipes/cuda-toolkit/${{ matrix.cuda-version }}/test_package cuda-toolkit/13.4.0-preview -s arch=${{ matrix.cross-arch }} -c tools.cmake.cmaketoolchain:generator=Ninja
 
       - name: build cuda-samples
-        if: matrix.cuda-version == '13.2' || (matrix.cuda-version == '13.4' && startsWith(matrix.os, 'windows'))
+        if: matrix.os != 'windows-11-arm' && (matrix.cuda-version == '13.2' || (matrix.cuda-version == '13.4' && startsWith(matrix.os, 'windows')))
         working-directory: samples/cuda-samples
         run: |
           conan source .

--- a/samples/cuda-samples/.gitignore
+++ b/samples/cuda-samples/.gitignore
@@ -1,0 +1,2 @@
+src/
+build/

--- a/samples/cuda-samples/conanfile.py
+++ b/samples/cuda-samples/conanfile.py
@@ -1,6 +1,8 @@
+import os
+
 from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
-from conan.tools.files import get
+from conan.tools.files import get, patch
 
 
 class cuda_samplesRecipe(ConanFile):
@@ -8,11 +10,14 @@ class cuda_samplesRecipe(ConanFile):
     version = "13.2"
     package_type = "application"
     settings = "os", "compiler", "build_type", "arch"
+    exports_sources = "patches/*.patch"
 
     def source(self):
         cuda_samples_url = "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v13.2update.tar.gz"
         cuda_samples_checksum = "057e68d22bd02e41d60c9826e7622ac1b88de0f1dbe25ed49bd995f768306f9d"
         get(self, cuda_samples_url, sha256=cuda_samples_checksum, strip_root=True)
+        patch_file = os.path.join(self.export_sources_folder, "patches", "13.2-windows-fixes.patch")
+        patch(self, patch_file=patch_file)
 
     def requirements(self):
         self.requires("cuda-toolkit/[>=13 <14]")

--- a/samples/cuda-samples/conanfile.py
+++ b/samples/cuda-samples/conanfile.py
@@ -1,0 +1,39 @@
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+from conan.tools.files import get
+
+
+class cuda_samplesRecipe(ConanFile):
+    name = "cuda-samples"
+    version = "13.2"
+    package_type = "application"
+    settings = "os", "compiler", "build_type", "arch"
+
+    def source(self):
+        cuda_samples_url = "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v13.2update.tar.gz"
+        cuda_samples_checksum = "057e68d22bd02e41d60c9826e7622ac1b88de0f1dbe25ed49bd995f768306f9d"
+        get(self, cuda_samples_url, sha256=cuda_samples_checksum, strip_root=True)
+
+    def requirements(self):
+        self.requires("cuda-toolkit/[>=13 <14]")
+        self.requires("opengl/system")
+        self.requires("freeimage/[*]")
+
+    def build_requirements(self):
+        self.tool_requires("cuda-toolkit/<host_version>")
+        self.tool_requires("cmake/[*]")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.set_property("freeimage", "cmake_file_name", "FreeImage")
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()

--- a/samples/cuda-samples/patches/13.2-windows-fixes.patch
+++ b/samples/cuda-samples/patches/13.2-windows-fixes.patch
@@ -1,0 +1,82 @@
+Add missing <iostream> for std::cout in cdpQuadtree.cu
+Disable Windows-specific post-build copy commands in CMakeLists.txt files for several CUDA samples
+(the DLL may not be present, and Conan handles dependencies at runtime)
+
+diff --git a/cpp/3_CUDA_Features/cdpQuadtree/cdpQuadtree.cu b/cpp/3_CUDA_Features/cdpQuadtree/cdpQuadtree.cu
+index 804d255..1c5a105 100644
+--- a/cpp/3_CUDA_Features/cdpQuadtree/cdpQuadtree.cu
++++ b/cpp/3_CUDA_Features/cdpQuadtree/cdpQuadtree.cu
+@@ -30,6 +30,8 @@
+ #include <thrust/host_vector.h>
+ #include <thrust/random.h>
+ 
++#include <iostream>
++
+ // for cuda::std::tuple
+ #include <cuda/std/tuple>
+ 
+diff --git a/cpp/4_CUDA_Libraries/FilterBorderControlNPP/CMakeLists.txt b/cpp/4_CUDA_Libraries/FilterBorderControlNPP/CMakeLists.txt
+index ee6a980..046c081 100644
+--- a/cpp/4_CUDA_Libraries/FilterBorderControlNPP/CMakeLists.txt
++++ b/cpp/4_CUDA_Libraries/FilterBorderControlNPP/CMakeLists.txt
+@@ -57,7 +57,7 @@ target_compile_features(FilterBorderControlNPP PRIVATE cxx_std_17 cuda_std_17)
+         ${CMAKE_CURRENT_SOURCE_DIR}/data
+         ${CMAKE_CURRENT_BINARY_DIR}/data
+     )
+-    if(WIN32)
++    if(0)
+         add_custom_command(TARGET FilterBorderControlNPP
+         POST_BUILD
+         COMMAND ${CMAKE_COMMAND} -E copy
+diff --git a/cpp/4_CUDA_Libraries/boxFilterNPP/CMakeLists.txt b/cpp/4_CUDA_Libraries/boxFilterNPP/CMakeLists.txt
+index 0ac3682..0b0e10d 100644
+--- a/cpp/4_CUDA_Libraries/boxFilterNPP/CMakeLists.txt
++++ b/cpp/4_CUDA_Libraries/boxFilterNPP/CMakeLists.txt
+@@ -54,7 +54,7 @@ target_compile_features(boxFilterNPP PRIVATE cxx_std_17 cuda_std_17)
+         ${CMAKE_CURRENT_SOURCE_DIR}/teapot512.pgm
+         ${CMAKE_CURRENT_BINARY_DIR}
+     )
+-    if(WIN32)
++    if(0)
+         add_custom_command(TARGET boxFilterNPP
+         POST_BUILD
+         COMMAND ${CMAKE_COMMAND} -E copy
+diff --git a/cpp/4_CUDA_Libraries/cannyEdgeDetectorNPP/CMakeLists.txt b/cpp/4_CUDA_Libraries/cannyEdgeDetectorNPP/CMakeLists.txt
+index 5cfffd7..78fe243 100644
+--- a/cpp/4_CUDA_Libraries/cannyEdgeDetectorNPP/CMakeLists.txt
++++ b/cpp/4_CUDA_Libraries/cannyEdgeDetectorNPP/CMakeLists.txt
+@@ -54,7 +54,7 @@ target_compile_features(cannyEdgeDetectorNPP PRIVATE cxx_std_17 cuda_std_17)
+         ${CMAKE_CURRENT_SOURCE_DIR}/teapot512.pgm
+         ${CMAKE_CURRENT_BINARY_DIR}
+     )
+-    if(WIN32)
++    if(0)
+         add_custom_command(TARGET cannyEdgeDetectorNPP
+         POST_BUILD
+         COMMAND ${CMAKE_COMMAND} -E copy
+diff --git a/cpp/4_CUDA_Libraries/freeImageInteropNPP/CMakeLists.txt b/cpp/4_CUDA_Libraries/freeImageInteropNPP/CMakeLists.txt
+index b3e89dc..42a2c58 100644
+--- a/cpp/4_CUDA_Libraries/freeImageInteropNPP/CMakeLists.txt
++++ b/cpp/4_CUDA_Libraries/freeImageInteropNPP/CMakeLists.txt
+@@ -54,7 +54,7 @@ if(${FreeImage_FOUND})
+         ${CMAKE_CURRENT_SOURCE_DIR}/../../../Common/data/teapot512.pgm
+         ${CMAKE_CURRENT_BINARY_DIR}/
+     )
+-    if(WIN32)
++    if(0)
+         add_custom_command(TARGET freeImageInteropNPP
+         POST_BUILD
+         COMMAND ${CMAKE_COMMAND} -E copy
+diff --git a/cpp/4_CUDA_Libraries/histEqualizationNPP/CMakeLists.txt b/cpp/4_CUDA_Libraries/histEqualizationNPP/CMakeLists.txt
+index 616d2c8..d2930c0 100644
+--- a/cpp/4_CUDA_Libraries/histEqualizationNPP/CMakeLists.txt
++++ b/cpp/4_CUDA_Libraries/histEqualizationNPP/CMakeLists.txt
+@@ -55,7 +55,7 @@ if(${FreeImage_FOUND})
+         ${CMAKE_CURRENT_SOURCE_DIR}/../../../Common/data/teapot512.pgm
+         ${CMAKE_CURRENT_BINARY_DIR}/
+     )
+-    if(WIN32)
++    if(0)
+         add_custom_command(TARGET histEqualizationNPP
+         POST_BUILD
+         COMMAND ${CMAKE_COMMAND} -E copy


### PR DESCRIPTION
Add a recipe to build `cuda-samples` from source: https://github.com/nvidia/cuda-samples

The intended workflow is to build it locally:

```
cd samples/cuda-samples
conan source .
conan build .
```

and then `source conanrun.sh` or equivalent to run the desired sample directly from the build tree

Also add CI to cover building CUDA samples:
- Linux x86_64 + cuda 13.2
- Linux aarch64 + cuda 13.2
- Windows x86_64 + cuda 13.2
- Windows x86_64 + cuda 13.4 (developer preview)
- ~Windows arm64 + cuda 13.4 (developer preview)~ (this one wont build due to vendored GLEW being x86_64)