### PR TITLE
Add cuda-toolkit/13.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
             cuda-version: "13.2"
           - os: ubuntu-24.04-arm
             cuda-version: "13.2"
+          - os: ubuntu-latest
+            cuda-version: "13.3"
+          - os: ubuntu-24.04-arm
+            cuda-version: "13.3"
           # Windows:
           # cuda <13.2 requires Visual Studio 2022, available on windows-2022 runner
           - os: windows-2022
@@ -29,6 +33,8 @@ jobs:
           # cuda >=13.2 can run on windows-latest (Visual Studio 2026)
           - os: windows-latest
             cuda-version: "13.2"
+          - os: windows-latest
+            cuda-version: "13.3"
           # 13.4.0-preview developer preview: Windows x86_64 and arm64
           - os: windows-latest
             cuda-version: "13.4"

--- a/recipes/cuda-toolkit/13.3/conanfile.py
+++ b/recipes/cuda-toolkit/13.3/conanfile.py
@@ -1,0 +1,151 @@
+import os
+import json
+from pathlib import Path
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import copy, download, get, load, rename, replace_in_file
+
+class CudaToolkitConan(ConanFile):
+    name = "cuda-toolkit"
+    package_type = "shared-library"
+    version = "13.3.1"
+    license = "CUDA Toolkit End-User License Agreement"
+    url = "https://github.com/conan-io/cuda-conan"
+    homepage = "https://developer.nvidia.com/cuda-toolkit"
+    description = "A development environment for creating high performance GPU-accelerated applications"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def validate(self):
+        if self.settings.os not in ["Windows", "Linux"]:
+            raise ConanInvalidConfiguration("Operating system not supported")
+
+        # TODO: Add checks for supported compilers as per https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#id56
+
+    def build(self):
+        base_url = "https://developer.download.nvidia.com/compute/cuda/redist"
+        distrib = f"redistrib_{self.version}.json"
+        json_distrib = f"{base_url}/{distrib}"
+        download(self, url=json_distrib, filename=distrib)
+        json_content = load(self, distrib)
+        cuda_distrib = json.loads(json_content)
+
+        if self.settings.os == "Linux" and self.settings.arch == "armv8":
+            cuda_platform = "linux-sbsa"
+        else:
+            cuda_platform = f"{str(self.settings.os).lower()}-{self.settings.arch}"
+
+        self.output.info(f"About to download CUDA toolkit components for {cuda_platform}")
+
+        components = [
+            "cccl",
+            "cuda_crt",
+            "cuda_cudart",
+            "cuda_cupti",
+            "cuda_cuxxfilt",
+            "cuda_nvcc",
+            "cuda_nvml_dev",
+            "cuda_nvrtc",
+            "cuda_nvtx",
+            "cuda_profiler_api",
+            "cuda_sanitizer_api",
+            "libcublas",
+            "libcufft",
+            "libcurand",
+            "libcusolver",
+            "libcusparse",
+            "libnpp",
+            "libnvfatbin",
+            "libnvjitlink",
+            "libnvjpeg",
+            "libnvptxcompiler",
+            "libnvvm",
+            "cuda_tileiras",
+        ]
+
+        platform_components = {
+            "linux-x86_64": ["libcufile", "cuda_sandbox_dev", "cuda_opencl", "cuda_culibos", "cuda_compat", "libcuobjclient"],
+            "linux-sbsa": ["libcufile", "cuda_sandbox_dev", "cuda_culibos", "cuda_compat", "cuda_compat_orin", "libcudla", "libcuobjclient"],
+            "windows-x86_64": ["cuda_opencl", "visual_studio_integration"],
+        }
+        components += platform_components.get(cuda_platform, [])
+
+        for component_name, data in cuda_distrib.items():
+            if component_name not in components:
+                self.output.info(f"Skipping {component_name}")
+                continue
+            else:
+                self.output.info(f"About to download {component_name} for {cuda_platform}")
+
+            url = f"{base_url}/{(data[cuda_platform]['cuda13.3'] if component_name == 'cuda_compat' else data[cuda_platform])['relative_path']}"
+            checksum = (data[cuda_platform]['cuda13.3'] if component_name == 'cuda_compat' else data[cuda_platform])['sha256']
+
+            get(self, url, sha256=checksum, destination="cuda", strip_root=True, keep_permissions=False)
+            rename(self, f"{self.build_folder}/cuda/LICENSE", f"LICENSE_{component_name}")
+        if self.settings.os == "Linux":
+            # When crossbuilding, point nvcc to the target directory in the "host" package (for the target architecture),
+            # rather than have it look relative to itself (which is the current architecture of the build machine)
+            replace_in_file(self, "cuda/bin/nvcc.profile", '$(TOP)/$(_TARGET_DIR_)/', '$(CONAN_CUDA_TARGET_DIR)/')
+            replace_in_file(self, "cuda/bin/nvcc.profile", "lib$(_TARGET_SIZE_)", "lib" )
+
+    def package(self):
+        copy(self, "LICENSE*", src=self.build_folder, dst=os.path.join(self.package_folder, "licenses"))
+
+        for folder in ["bin", "nvml", "nvvm", "compat", "compat_orin"]:
+            copy(self, "*", src=os.path.join(self.build_folder, "cuda", folder), dst=os.path.join(self.package_folder, folder))
+
+        if self.settings.os == "Linux":
+            arch = "sbsa" if self.settings.arch == "armv8" else str(self.settings.arch)
+            targets_folder = f"targets/{arch}-linux"
+            copy(self, "*", src=os.path.join(self.build_folder, "cuda", "lib"), dst=os.path.join(self.package_folder, targets_folder, "lib"))
+            copy(self, "*", src=os.path.join(self.build_folder, "cuda", "include"), dst=os.path.join(self.package_folder, targets_folder, "include"))
+            copy(self, "*", src=os.path.join(self.build_folder, "cuda", "res"), dst=os.path.join(self.package_folder, targets_folder, "res"))
+
+            include_symlink = Path(f"targets/{arch}-linux/include")
+            lib64_symlink = Path(f"targets/{arch}-linux/lib")
+            res_symlink = Path(f"targets/{arch}-linux/res")
+            include = Path(os.path.join(self.package_folder, "include"))
+            lib = Path(os.path.join(self.package_folder, "lib64"))
+            res = Path(os.path.join(self.package_folder, "res"))
+            include.symlink_to(include_symlink)
+            lib.symlink_to(lib64_symlink)
+            res.symlink_to(res_symlink)
+        elif self.settings.os == "Windows":
+            for folder in ["compute-sanitizer", "include", "lib"]:
+                copy(self, "*", src=os.path.join(self.build_folder, "cuda", folder), dst=os.path.join(self.package_folder, folder))
+
+            copy(self, "*", src=os.path.join(self.build_folder, "cuda", "visual_studio_integration"),
+                            dst=os.path.join(self.package_folder, "extras", "visual_studio_integration") )
+
+    def package_id(self):
+        # only os and arch matter for this package
+        self.info.settings.rm_safe("compiler")
+        self.info.settings.rm_safe("build_type")
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "CUDAToolkit") # what consumers will expect
+        self.cpp_info.set_property("cmake_find_mode", "none") # but don't generate it
+        self.cpp_info.set_property("cmake_target_name", "CUDA::toolkit")
+
+        nvcc = "nvcc.exe" if self.settings.os == "Windows" else "nvcc"
+        self.buildenv_info.define_path("CUDACXX", os.path.join(self.package_folder, "bin", nvcc))
+
+        if not self.settings_target:
+            arch = "sbsa" if self.settings.arch == "armv8" else str(self.settings.arch)
+            self.buildenv_info.define_path("CUDAToolkit_ROOT", self.package_folder)
+            self.buildenv_info.define_path("CONAN_CUDA_TARGET_DIR", os.path.join(self.package_folder, "targets", f"{arch}-linux"))
+        
+        if self.settings.os == "Linux":
+            self.cpp_info.libdirs = ["lib64"]
+        else:
+            self.cpp_info.libdirs = ["lib", "lib/x64"]
+            self.cpp_info.bindirs = ["bin", "bin/x64"]
+
+        if self.settings_build.os == "Windows":
+            # Only has effect when Windows and the CMake generator is Visual Studio
+            package_folder = f"{self.package_folder}".replace('\\', '/')
+            self.conf_info.define("tools.cmake.cmaketoolchain:toolset_cuda", package_folder)
+
+        if self.settings_target and self.settings_target.get_safe("build_type"):
+            self.conf_info.update("tools.cmake.cmaketoolchain:extra_variables",
+                                    {"CMAKE_TRY_COMPILE_CONFIGURATION": str(self.settings_target.build_type)})

--- a/recipes/cuda-toolkit/13.3/test_package/CMakeLists.txt
+++ b/recipes/cuda-toolkit/13.3/test_package/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.25)
+
+project(PackageTest LANGUAGES CXX CUDA)
+
+find_package(CUDAToolkit REQUIRED)
+
+message("CUDAToolkit_VERSION: ${CUDAToolkit_VERSION}")
+message("CUDAToolkit_BIN_DIR: ${CUDAToolkit_BIN_DIR}")
+message("CUDAToolkit_LIBRARY_DIR: ${CUDAToolkit_LIBRARY_DIR}")
+message("CUDAToolkit_LIBRARY_ROOT: ${CUDAToolkit_LIBRARY_ROOT}")
+message("CUDAToolkit_NVCC_EXECUTABLE: ${CUDAToolkit_NVCC_EXECUTABLE}")
+
+add_executable(example hello_cuda.cu)
+target_compile_options(example PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--verbose>)

--- a/recipes/cuda-toolkit/13.3/test_package/conanfile.py
+++ b/recipes/cuda-toolkit/13.3/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class CudatoolkitTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+        self.tool_requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self, src_folder='.')
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "example")
+            self.run(bin_path, env="conanrun")

--- a/recipes/cuda-toolkit/13.3/test_package/hello_cuda.cu
+++ b/recipes/cuda-toolkit/13.3/test_package/hello_cuda.cu
@@ -1,0 +1,51 @@
+#include <stdio.h>
+#include <cuda_runtime.h>
+
+__global__ void helloKernel(void) {
+    printf("Hello from GPU thread (%d, %d)\n",
+           blockIdx.x, threadIdx.x);
+}
+
+int main(void) {
+    /* ── 1. Check driver / runtime availability ── */
+    int driverVersion = 0, runtimeVersion = 0;
+    cudaError_t err;
+
+    err = cudaDriverGetVersion(&driverVersion);
+    if (err != cudaSuccess || driverVersion == 0) {
+        printf("Hello from CPU! (no CUDA driver: %s)\n",
+               cudaGetErrorString(err));
+        return 0;
+    }
+
+    cudaRuntimeGetVersion(&runtimeVersion);
+
+    /* ── 2. Enumerate devices ── */
+    int deviceCount = 0;
+    err = cudaGetDeviceCount(&deviceCount);
+    if (err != cudaSuccess || deviceCount == 0) {
+        printf("Hello from CPU! (no CUDA devices: %s)\n",
+               cudaGetErrorString(err));
+        return 0;
+    }
+
+    /* ── 3. Print basic device info ── */
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, 0);
+    printf("CUDA driver %d.%d  |  runtime %d.%d  |  device 0: %s\n",
+           driverVersion / 1000, (driverVersion % 100) / 10,
+           runtimeVersion / 1000, (runtimeVersion % 100) / 10,
+           prop.name);
+
+    /* ── 4. Launch kernel ── */
+    helloKernel<<<2, 4>>>();
+
+    err = cudaDeviceSynchronize();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "Kernel failed: %s\n", cudaGetErrorString(err));
+        return 1;
+    }
+
+    printf("Hello from CPU! (kernel completed successfully)\n");
+    return 0;
+}

--- a/recipes/cuda-toolkit/config.yml
+++ b/recipes/cuda-toolkit/config.yml
@@ -1,6 +1,8 @@
 versions:
   "13.4.0-preview":
     folder: "13.4"
+  "13.3.1":
+    folder: "13.3"
   "13.2.2":
     folder: "13.2"
   "13.0.3":


### PR DESCRIPTION
Adds `cuda-toolkit/13.3.1`, based on the 13.2 recipe. 

Cuda component `cuda_cccl` renamed to `cccl` upstream

Added 13.3 to the CI matrix for `ubuntu-latest`, `ubuntu-24.04-arm`, and `windows-latest`.

## Test plan
- [x] `conan create` passes on Windows x86_64; test package compiles and runs
- [x] CI: Linux x86_64, Linux arm64, Windows x86_64